### PR TITLE
fix: pin pygaul<0.4 to avoid GAUL 2024 property mismatch

### DIFF
--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pandas
   - tf-keras
   - sepal-ui>=2.22.1,<3
+  - pygaul<0.4  # pin to avoid GAUL 2024 property name mismatch with sepal_ui
   - rasterio<=1.4.3
   - pip
   - pip:


### PR DESCRIPTION
## Summary
Pin `pygaul<0.4` in `sepal_environment.yml` to avoid the GAUL 2024 administrative boundary code change (FAO 2024 update) that is incompatible with `sepal_ui<3`.

## Why
`sepal_ui<3` expects GAUL 2010 admin codes and property names. `pygaul>=0.4` switched to GAUL 2024 codes with renamed properties, breaking admin-boundary lookups and AOI selection across all modules still on the 2.x sepal_ui line.

## Test plan
- [ ] conda env solves with the new pin
- [ ] Module launches without import errors
- [ ] Admin boundary / AOI selection works as before